### PR TITLE
rv_discrete.ppf() to handle loc

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -3236,8 +3236,8 @@ class rv_discrete(rv_generic):
         cond = cond0 & cond1
         output = valarray(shape(cond), value=self.badvalue, typecode='d')
         # output type 'd' to handle nin and inf
-        place(output, (q == 0)*(cond == cond), _a-1)
-        place(output, cond2, _b)
+        place(output, (q == 0)*(cond == cond), _a-1 + loc)
+        place(output, cond2, _b + loc)
         if np.any(cond):
             goodargs = argsreduce(cond, *((q,)+args+(loc,)))
             loc, goodargs = goodargs[-1], goodargs[:-1]


### PR DESCRIPTION


<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Issue #11132

#### What does this implement/fix?
<!--Please explain your changes.-->
Updated  rv_discrete to support shifting loc of distribution. Before this change ppf(0) and ppf(1) returns the same result (respectively _a = min(xk) - 1 and _b = max(xk)), even though the optional parameter `loc` is given. 
After the change ppf(0) = _a + loc and ppf(1) = _b + loc

#### Additional information
<!--Any additional information you think is important.-->
Thanks to @josef-pkt for his comments!